### PR TITLE
Change 'opacities' to 'opacity' in the example snippets

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,7 +33,7 @@ require("tailwind-heropatterns")({
   },
 
   // The foreground opacity
-  opacities: {
+  opacity: {
     default: "0.4",
     "100": "1.0"
   }
@@ -87,7 +87,7 @@ require("tailwind-heropatterns")({
   colors: {
     default: "#9C92AC"
   },
-  opacities: {
+  opacity: {
     default: "0.4"
   }
 });


### PR DESCRIPTION
Hi,

thank you for the useful tailwind plugin! 

I found an issue and solved it: I have copied and pasted the example snippets from the README. But I could not change the default opacity because of the wrong propertyname. 

In the README the property is called: `opacities` and in the code `opacity`. So I equalized them. 

Or did I miss something?